### PR TITLE
mahi#19 mahi v1 crash on bad role mgmt log entry

### DIFF
--- a/v1/lib/auth_cache.js
+++ b/v1/lib/auth_cache.js
@@ -735,6 +735,9 @@ function removeGroupMember(self, userdn, groupdn, cb) {
                 user: payload
             }, 'got user entry');
             payload = JSON.parse(payload);
+            if (typeof (payload.groups) !== 'object' || payload.groups === null) {
+                payload.groups = {};
+            }
             delete payload.groups[group];
             payload = JSON.stringify(payload);
             log.info({


### PR DESCRIPTION
testing done:
 * patched into production installation to stop it from crashing
 * ran `make check`
   - it fails in the copyright check, but I have no right to update a joyent copyright line